### PR TITLE
Sort Events feature

### DIFF
--- a/src/main/java/ezschedule/logic/commands/SortCommand.java
+++ b/src/main/java/ezschedule/logic/commands/SortCommand.java
@@ -1,0 +1,24 @@
+package ezschedule.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import ezschedule.logic.commands.exceptions.CommandException;
+import ezschedule.model.Model;
+
+/**
+ * Sort all events in the scheduler in chronological order.
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort";
+
+    public static final String MESSAGE_SUCCESS = "Events sorted in order.";
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.sortEvents();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/ezschedule/logic/parser/SchedulerParser.java
+++ b/src/main/java/ezschedule/logic/parser/SchedulerParser.java
@@ -13,6 +13,7 @@ import ezschedule.logic.commands.ExitCommand;
 import ezschedule.logic.commands.FindCommand;
 import ezschedule.logic.commands.HelpCommand;
 import ezschedule.logic.commands.ListCommand;
+import ezschedule.logic.commands.SortCommand;
 import ezschedule.logic.parser.exceptions.ParseException;
 
 /**
@@ -59,6 +60,9 @@ public class SchedulerParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/ezschedule/model/Model.java
+++ b/src/main/java/ezschedule/model/Model.java
@@ -81,6 +81,11 @@ public interface Model {
     void setEvent(Event target, Event editedEvent);
 
     /**
+     * Sorts all the events in the event list in chronological order.
+     */
+    void sortEvents();
+
+    /**
      * Returns an unmodifiable view of the filtered event list
      */
     ObservableList<Event> getFilteredEventList();

--- a/src/main/java/ezschedule/model/ModelManager.java
+++ b/src/main/java/ezschedule/model/ModelManager.java
@@ -110,6 +110,11 @@ public class ModelManager implements Model {
         scheduler.setEvent(target, editedEvent);
     }
 
+    @Override
+    public void sortEvents() {
+        scheduler.sortEvent();
+    }
+
     //=========== Filtered Event List Accessors =============================================================
 
     /**

--- a/src/main/java/ezschedule/model/Scheduler.java
+++ b/src/main/java/ezschedule/model/Scheduler.java
@@ -85,6 +85,13 @@ public class Scheduler implements ReadOnlyScheduler {
     }
 
     /**
+     * Sorts all events in the scheduler in chronological order.
+     */
+    public void sortEvent() {
+        events.sortByChronologicalOrder();
+    }
+
+    /**
      * Removes {@code key} from this {@code Scheduler}.
      * {@code key} must exist in the scheduler
      */

--- a/src/main/java/ezschedule/model/event/UniqueEventList.java
+++ b/src/main/java/ezschedule/model/event/UniqueEventList.java
@@ -99,6 +99,13 @@ public class UniqueEventList implements Iterable<Event> {
     }
 
     /**
+     * Sorts all events in chronological order.
+     */
+    public void sortByChronologicalOrder() {
+        FXCollections.sort(internalList);
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Event> asUnmodifiableObservableList() {

--- a/src/main/java/ezschedule/ui/UiManager.java
+++ b/src/main/java/ezschedule/ui/UiManager.java
@@ -36,12 +36,12 @@ public class UiManager implements Ui {
     public void start(Stage primaryStage) {
         logger.info("Starting UI...");
 
-        //Set the application icon.
+        // Set the application icon
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
 
         try {
             mainWindow = new MainWindow(primaryStage, logic);
-            mainWindow.show(); //This should be called before creating other UI parts
+            mainWindow.show(); // This should be called before creating other UI parts
             mainWindow.fillInnerParts();
 
         } catch (Throwable e) {

--- a/src/test/java/ezschedule/logic/commands/AddCommandTest.java
+++ b/src/test/java/ezschedule/logic/commands/AddCommandTest.java
@@ -139,6 +139,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void sortEvents() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Event> getFilteredEventList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/ezschedule/logic/commands/SortCommandTest.java
+++ b/src/test/java/ezschedule/logic/commands/SortCommandTest.java
@@ -1,0 +1,124 @@
+package ezschedule.logic.commands;
+
+import static ezschedule.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ezschedule.testutil.TypicalEvents.getTypicalScheduler;
+
+import org.junit.jupiter.api.Test;
+
+import ezschedule.model.Model;
+import ezschedule.model.ModelManager;
+import ezschedule.model.Scheduler;
+import ezschedule.model.UserPrefs;
+import ezschedule.model.event.Event;
+import ezschedule.testutil.EventBuilder;
+import ezschedule.testutil.SchedulerBuilder;
+import ezschedule.testutil.TypicalEvents;
+
+public class SortCommandTest {
+
+    private Model model = new ModelManager(getTypicalScheduler(), new UserPrefs());
+
+    @Test
+    public void execute_typicalEventsAbcd_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        Scheduler scheduler = new SchedulerBuilder()
+                .withEvent(TypicalEvents.CARNIVAL)
+                .withEvent(TypicalEvents.ART)
+                .withEvent(TypicalEvents.DRAG)
+                .withEvent(TypicalEvents.BOAT)
+                .build();
+        Model givenModel = new ModelManager(scheduler, new UserPrefs());
+
+        assertCommandSuccess(new SortCommand(), givenModel, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_typicalEventAEventB_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        Model givenModel = new ModelManager(
+                new SchedulerBuilder()
+                    .withEvent(TypicalEvents.EVENT_B)
+                    .withEvent(TypicalEvents.EVENT_A)
+                    .build(),
+                new UserPrefs());
+
+        Model expectedModel = new ModelManager(
+                new SchedulerBuilder()
+                        .withEvent(TypicalEvents.EVENT_A)
+                        .withEvent(TypicalEvents.EVENT_B)
+                        .build(),
+                new UserPrefs());
+
+        assertCommandSuccess(new SortCommand(), givenModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_customEventsSameDate_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        // Events are build with default date, end time
+        Event e1 = new EventBuilder().withName("e1").withStartTime("12:34").build();
+        Event e2 = new EventBuilder().withName("e2").withStartTime("21:43").build();
+
+        Model givenModel = new ModelManager(
+                new SchedulerBuilder().withEvent(e2).withEvent(e1).build(),
+                new UserPrefs());
+
+        Model expectedModel = new ModelManager(
+                new SchedulerBuilder().withEvent(e1).withEvent(e2).build(),
+                new UserPrefs());
+
+        assertCommandSuccess(new SortCommand(), givenModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_customEventsSameTime_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        // Events are build with default date, end time
+        Event e1 = new EventBuilder().withName("e1").withDate("2023-05-01").build();
+        Event e2 = new EventBuilder().withName("e2").withDate("2023-05-02").build();
+
+        Model givenModel = new ModelManager(
+                new SchedulerBuilder().withEvent(e2).withEvent(e1).build(),
+                new UserPrefs());
+
+        Model expectedModel = new ModelManager(
+                new SchedulerBuilder().withEvent(e1).withEvent(e2).build(),
+                new UserPrefs());
+
+        assertCommandSuccess(new SortCommand(), givenModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_customEvents_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        // Events are build with default date, end time
+        // e1 have earlier date, later time
+        // e2 have later date, earlier time
+        // e1 is expected to come before e2
+        Event e1 = new EventBuilder()
+                .withName("e1")
+                .withDate("2023-05-01")
+                .withStartTime("21:43")
+                .build();
+        Event e2 = new EventBuilder()
+                .withName("e2")
+                .withDate("2023-05-02")
+                .withStartTime("12:34")
+                .build();
+
+        Model givenModel = new ModelManager(
+                new SchedulerBuilder().withEvent(e2).withEvent(e1).build(),
+                new UserPrefs());
+
+        Model expectedModel = new ModelManager(
+                new SchedulerBuilder().withEvent(e1).withEvent(e2).build(),
+                new UserPrefs());
+
+        assertCommandSuccess(new SortCommand(), givenModel, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/ezschedule/logic/parser/SchedulerParserTest.java
+++ b/src/test/java/ezschedule/logic/parser/SchedulerParserTest.java
@@ -22,6 +22,7 @@ import ezschedule.logic.commands.ExitCommand;
 import ezschedule.logic.commands.FindCommand;
 import ezschedule.logic.commands.HelpCommand;
 import ezschedule.logic.commands.ListCommand;
+import ezschedule.logic.commands.SortCommand;
 import ezschedule.logic.parser.exceptions.ParseException;
 import ezschedule.model.event.Event;
 import ezschedule.model.event.EventContainsKeywordsPredicate;
@@ -51,6 +52,11 @@ public class SchedulerParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_EVENT.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_EVENT), command);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD) instanceof SortCommand);
     }
 
     @Test


### PR DESCRIPTION
- Make `Event` comparable (via Date and Start Time) - chronological order [committed previously]
- Add a `SortCommand` to initiate a sorting of all events in the scheduler
- Add 5 test cases for `SortCommand`
  - Test general sorting in order
  - Test sorting events of same date, different start time
  - Test sorting events of different date, same start time
  - Test sorting events of "opposing" date and start time
 
This PR closes #56.