### PR TITLE
Add task dependency when generating jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,13 @@ dependencies {
 }
 
 shadowJar {
+    dependsOn test
+    dependsOn checkstyleMain
+    dependsOn checkstyleTest
     archiveFileName = 'Ez-Schedule.jar'
+    doLast {
+        println "Generated *.jar can be found at /build/libs/"
+    }
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Gradle tasks test, checkstyleMain. checkstyleTest
needs to be passed first before shadowJar is run.