### PR TITLE
Fix wrong calendar event name bug

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -289,35 +289,35 @@ _{more aspects and alternatives to be added}_
 
 _{Explain here how the data archiving feature will be implemented}_
 
-### \[Proposed\] Calender view feature
+### \[Proposed\] Calendar view feature
 
 #### Proposed Implementation
 
-The proposed calender view user interface implements the following operations:
+The proposed calendar view user interface implements the following operations:
 
 1. Provides an overview of all saved events in the scheduler to the user
-2. onClick() of calender date (boxes) - List all the saved events the user have for that day
+2. onClick() of calendar date (boxes) - List all the saved events the user have for that day
 
 The feature is going to be implemented by
-1. Creating the GUI of a calender via JavaFX (Calender.fxml and CalenderBox.fxml)
+1. Creating the GUI of a calendar via JavaFX (Calendar.fxml and CalendarBox.fxml)
 2. When the program starts, it first fetches the existing events
-3. The calender will next be "drawn" with the events for the current month
-4. The calender includes button that allow users to go to either the next or previous month, each time the button is called, the calender is "redrawn" with that particular month's events
-5. When a user were to click a date in the calender (CalenderBox.fxml), it will list all existing events of that day to the user
-6. When a user were to add, edit or update an event, the calender will be updated as well
+3. The calendar will next be "drawn" with the events for the current month
+4. The calendar includes button that allow users to go to either the next or previous month, each time the button is called, the calendar is "redrawn" with that particular month's events
+5. When a user were to click a date in the calendar (CalendarBox.fxml), it will list all existing events of that day to the user
+6. When a user were to add, edit or update an event, the calendar will be updated as well
 
 #### Design considerations:
-* **Alternative 1 (current choice):** Update the Calender GUI whenever add/edit/delete an event.
+* **Alternative 1 (current choice):** Update the Calendar GUI whenever add/edit/delete an event.
     * Pros: Easy to implement.
     * Cons: May have performance issues in terms of memory usage.
 
-* **Alternative 2:** Update the Calender GUI on if the month of the event is what the Calender is current showing
+* **Alternative 2:** Update the Calendar GUI on if the month of the event is what the Calendar is current showing
   itself.
     * Pros: Will have better performance (e.g. for `add event`, no need to update the GUI if it is not what I am currently showing, if I were to click next).
     * Cons: Implementation will become much more complex.
 
 #### Additional Feature
-1. onDoubleClick() of a calender date (boxes) - Shows a popup GUI of user schedule, similar to that of a timetable for either that day or week
+1. onDoubleClick() of a calendar date (boxes) - Shows a popup GUI of user schedule, similar to that of a timetable for either that day or week
 
 
 --------------------------------------------------------------------------------------------------------------------

--- a/src/main/java/ezschedule/model/event/Event.java
+++ b/src/main/java/ezschedule/model/event/Event.java
@@ -98,13 +98,13 @@ public class Event implements Comparable<Event> {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        sb.append("\n")
+        sb.append("\nName: ")
                 .append(getName())
-                .append("Date: ")
+                .append("\nDate: ")
                 .append(getDate())
-                .append("Start time: ")
+                .append("\nStart time: ")
                 .append(getStartTime())
-                .append("End time: ")
+                .append("\nEnd time: ")
                 .append(getEndTime());
         return sb.toString();
     }

--- a/src/main/java/ezschedule/ui/CalendarBox.java
+++ b/src/main/java/ezschedule/ui/CalendarBox.java
@@ -2,8 +2,10 @@ package ezschedule.ui;
 
 import java.util.List;
 
+import ezschedule.model.event.Date;
 import ezschedule.model.event.Event;
 import ezschedule.model.event.EventMatchesDatePredicate;
+import ezschedule.ui.Calendar.FilterExecutor;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
@@ -14,14 +16,14 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 
 /**
- * A UI component for the calendar.
+ * A UI component for the {@code Calendar}.
  */
 public class CalendarBox extends UiPart<Region> {
 
     private static final String FXML = "CalendarBox.fxml";
 
     private List<Event> events;
-    private Calendar.FilterExecutor filterExecutor;
+    private FilterExecutor filterExecutor;
 
     @FXML
     private StackPane calendarBoxPane;
@@ -42,16 +44,16 @@ public class CalendarBox extends UiPart<Region> {
     }
 
     /**
-     * Creates a {@code CalendarBox} with the given {@code List<Event>} and date to display.
+     * Creates a filled {@code CalendarBox} with the given {@code List<Event>} and date to display.
      */
     public CalendarBox(boolean isFind, boolean isToday, String date,
-                       List<Event> events, Calendar.FilterExecutor filterExecutor) {
+                       List<Event> events, FilterExecutor filterExecutor) {
         super(FXML);
         this.events = events;
         this.filterExecutor = filterExecutor;
         setHighlight(isFind);
-        setDate(date);
         setToday(isToday);
+        setDate(date);
         setEvents();
     }
 
@@ -61,7 +63,9 @@ public class CalendarBox extends UiPart<Region> {
     @FXML
     public void handleListEvents() {
         if (events != null) {
-            filterExecutor.updateFilteredEventList(new EventMatchesDatePredicate(events.get(0).getDate()));
+            int firstEventIndex = 0;
+            Date date = events.get(firstEventIndex).getDate();
+            filterExecutor.updateFilteredEventList(new EventMatchesDatePredicate(date));
         }
     }
 
@@ -69,10 +73,6 @@ public class CalendarBox extends UiPart<Region> {
         if (isFind) {
             calendarHighlight.setStroke(Color.DARKORANGE);
         }
-    }
-
-    private void setDate(String date) {
-        calendarDate.setText(date);
     }
 
     private void setToday(boolean isToday) {
@@ -84,24 +84,26 @@ public class CalendarBox extends UiPart<Region> {
         }
     }
 
+    private void setDate(String date) {
+        calendarDate.setText(date);
+    }
+
     private void setEvents() {
         if (events != null) {
-            int firstEvent = 0;
-            String eventNameOne = getEventName(events.get(firstEvent));
-            Label eventOne = new Label(eventNameOne);
-            setEventLabelStyle(eventOne);
-            calendarEvents.getChildren().add(eventOne);
+            int firstEventIndex = 0;
+            Event firstEvent = events.get(firstEventIndex);
+            String firstEventName = getEventName(firstEvent);
+            setEventLabel(firstEventName);
 
             if (events.size() == 2) {
-                int secondEvent = 0;
-                String eventNameTwo = getEventName(events.get(secondEvent));
-                Label eventTwo = new Label(eventNameTwo);
-                setEventLabelStyle(eventTwo);
-                calendarEvents.getChildren().add(eventTwo);
+                int secondEventIndex = 1;
+                Event secondEvent = events.get(secondEventIndex);
+                String secondEventName = getEventName(secondEvent);
+                setEventLabel(secondEventName);
+
             } else if (events.size() > 2) {
-                Label moreEvents = new Label("...");
-                setEventLabelStyle(moreEvents);
-                calendarEvents.getChildren().add(moreEvents);
+                String moreEvents = "...";
+                setEventLabel(moreEvents);
             }
         }
     }
@@ -122,11 +124,13 @@ public class CalendarBox extends UiPart<Region> {
         return name.substring(0, 5) + "...";
     }
 
-    private void setEventLabelStyle(Label label) {
+    private void setEventLabel(String name) {
+        Label label = new Label(name);
         label.setStyle("-fx-text-fill: white; "
                 + "-fx-background-color: #4c837a; "
                 + "-fx-background-radius: 5; "
                 + "-fx-font-size: 11; "
                 + "-fx-padding: 0 10 0 10;");
+        calendarEvents.getChildren().add(label);
     }
 }

--- a/src/main/java/ezschedule/ui/CalendarBox.java
+++ b/src/main/java/ezschedule/ui/CalendarBox.java
@@ -14,7 +14,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 
 /**
- * A UI component that displays information of {@code Event} in the calendar.
+ * A UI component for the calendar.
  */
 public class CalendarBox extends UiPart<Region> {
 
@@ -35,14 +35,14 @@ public class CalendarBox extends UiPart<Region> {
     private Label now;
 
     /**
-     * Creates an empty {@code CalenderBox}.
+     * Creates an empty {@code CalendarBox}.
      */
     public CalendarBox() {
         super(FXML);
     }
 
     /**
-     * Creates a {@code CalenderBox} with the given {@code List<Event>} and date to display.
+     * Creates a {@code CalendarBox} with the given {@code List<Event>} and date to display.
      */
     public CalendarBox(boolean isFind, boolean isToday, String date,
                        List<Event> events, Calendar.FilterExecutor filterExecutor) {

--- a/src/main/java/ezschedule/ui/CalendarBox.java
+++ b/src/main/java/ezschedule/ui/CalendarBox.java
@@ -62,11 +62,13 @@ public class CalendarBox extends UiPart<Region> {
      */
     @FXML
     public void handleListEvents() {
-        if (events != null) {
-            int firstEventIndex = 0;
-            Date date = events.get(firstEventIndex).getDate();
-            filterExecutor.updateFilteredEventList(new EventMatchesDatePredicate(date));
+        if (events == null) {
+            return;
         }
+
+        int firstEventIndex = 0;
+        Date date = events.get(firstEventIndex).getDate();
+        filterExecutor.updateFilteredEventList(new EventMatchesDatePredicate(date));
     }
 
     private void setHighlight(boolean isFind) {
@@ -89,22 +91,24 @@ public class CalendarBox extends UiPart<Region> {
     }
 
     private void setEvents() {
-        if (events != null) {
-            int firstEventIndex = 0;
-            Event firstEvent = events.get(firstEventIndex);
-            String firstEventName = getEventName(firstEvent);
-            setEventLabel(firstEventName);
+        if (events == null) {
+            return;
+        }
 
-            if (events.size() == 2) {
-                int secondEventIndex = 1;
-                Event secondEvent = events.get(secondEventIndex);
-                String secondEventName = getEventName(secondEvent);
-                setEventLabel(secondEventName);
+        int firstEventIndex = 0;
+        Event firstEvent = events.get(firstEventIndex);
+        String firstEventName = getEventName(firstEvent);
+        setEventLabel(firstEventName);
 
-            } else if (events.size() > 2) {
-                String moreEvents = "...";
-                setEventLabel(moreEvents);
-            }
+        if (events.size() == 2) {
+            int secondEventIndex = 1;
+            Event secondEvent = events.get(secondEventIndex);
+            String secondEventName = getEventName(secondEvent);
+            setEventLabel(secondEventName);
+
+        } else if (events.size() > 2) {
+            String moreEvents = "...";
+            setEventLabel(moreEvents);
         }
     }
 


### PR DESCRIPTION
1. Improve code quality in Calendar class
2. Improve code quality in CalendarBox class
3. Changed typo in "Calender/calender" to "Calendar/calender"
4. Fixed the bug of displaying the wrong calendar event name

Resolves #125 