### PR TITLE
Enhance SchedulerParser

### DIFF
--- a/src/main/java/ezschedule/logic/parser/SchedulerParser.java
+++ b/src/main/java/ezschedule/logic/parser/SchedulerParser.java
@@ -55,24 +55,50 @@ public class SchedulerParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+
+            if (!arguments.equals("")) {
+                throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+            } else {
+                return new ClearCommand();
+            }
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+
+            if (!arguments.equals("")) {
+                throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+            } else {
+                return new ListCommand();
+            }
 
         case ShowNextCommand.COMMAND_WORD:
             return new ShowNextCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+
+            if (!arguments.equals("")) {
+                throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+            } else {
+                return new ExitCommand();
+            }
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+
+            if (!arguments.equals("")) {
+                throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+            } else {
+                return new HelpCommand();
+            }
+
         case UndoCommand.COMMAND_WORD:
-            return new UndoCommand();
+
+            if (!arguments.equals("")) {
+                throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+            } else {
+                return new UndoCommand();
+            }
 
         case RecurCommand.COMMAND_WORD:
             return new RecurCommandParser().parse(arguments);

--- a/src/test/java/ezschedule/logic/parser/SchedulerParserTest.java
+++ b/src/test/java/ezschedule/logic/parser/SchedulerParserTest.java
@@ -45,7 +45,12 @@ public class SchedulerParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseClearCommand_withArguments_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -69,7 +74,12 @@ public class SchedulerParserTest {
     @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseExitCommand_withArguments_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand(ExitCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -84,13 +94,23 @@ public class SchedulerParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseHelpCommand_withArguments_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseListCommand_withArguments_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test


### PR DESCRIPTION
Previously, these are valid commands:
- help test
- list test
- exit test
- undo test

Now, enhanced SchedulerParser to be stricter with commands with no arguments. Commands with no arguments should strictly be on its own.

Invalid:
- help test

Valid: 
- help

Closes #152 