### PR TITLE
Update RecurCommand

### DIFF
--- a/src/main/java/ezschedule/logic/commands/RecurCommand.java
+++ b/src/main/java/ezschedule/logic/commands/RecurCommand.java
@@ -206,6 +206,11 @@ public class RecurCommand extends Command {
         }
     }
 
+    /**
+     * Returns a String of month with the given month int.
+     * @param month int of month to convert
+     * @return String name of month
+     */
     public String intToStringMonth(int month) {
         switch (month) {
 

--- a/src/main/java/ezschedule/logic/commands/RecurCommand.java
+++ b/src/main/java/ezschedule/logic/commands/RecurCommand.java
@@ -31,6 +31,8 @@ public class RecurCommand extends Command {
             + PREFIX_EVERY + "month ";
 
     public static final String MESSAGE_SUCCESS = "Recurring event added: %1$s";
+    public static final String MESSAGE_FAILURE_PAST_DATE = "End date indicated is in the past\n"
+            + "Ensure end date of recurrence has not past.";
     public static final String MESSAGE_RECUR_FACTOR_CAP = "Recur factor is not appropriate for "
             + "number of recurring events.";
     public static final String MESSAGE_FAILURE_DAY_NOT_EXIST_MONTH = "Unable to recur by month.\n"
@@ -64,6 +66,10 @@ public class RecurCommand extends Command {
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(String.format(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX,
                     index.getZeroBased() + 1));
+        }
+
+        if (endDate.isPastDate()) {
+            throw new CommandException(String.format(MESSAGE_FAILURE_PAST_DATE, endDate));
         }
 
         Event eventToRecur = lastShownList.get(index.getZeroBased());

--- a/src/main/java/ezschedule/logic/commands/RecurCommand.java
+++ b/src/main/java/ezschedule/logic/commands/RecurCommand.java
@@ -105,7 +105,7 @@ public class RecurCommand extends Command {
         int daysDiff = (int) baseDate.getDaysBetween(endDate.date);
 
         if (daysDiff > maxDaysInMonth) {
-            throw new CommandException(String.format(MESSAGE_RECUR_FACTOR_CAP));
+            throw new CommandException(MESSAGE_RECUR_FACTOR_CAP);
         }
 
         Date newDate = new Date(eventToRecur.getDate().date.plusDays(1).toString());

--- a/src/main/java/ezschedule/logic/parser/RecurCommandParser.java
+++ b/src/main/java/ezschedule/logic/parser/RecurCommandParser.java
@@ -44,7 +44,13 @@ public class RecurCommandParser implements Parser<RecurCommand> {
                     RecurCommand.MESSAGE_USAGE));
         }
 
-        index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, RecurCommand.MESSAGE_USAGE), pe);
+        }
+
         endDate = ParserUtil.parseDate(argMultimap.getValue(CliSyntax.PREFIX_DATE).get());
         recurFactor = ParserUtil.parseRecurFactor(argMultimap.getValue(CliSyntax.PREFIX_EVERY).get());
 


### PR DESCRIPTION
1. Update error message for parameters without index.

Resolves #168 

2. Fix last-day-of-month bug.
Previously, recurring `Event:2023-01-31` monthly does not indicate that February does not have day 31.

Now, an exception will be thrown to the user indicating an invalid recur due to the non-existence of 31st February (as per example above).

Events will now only be added if all days exist. 

Resolves #131 

3. Add error message for endDates in past.

Resolves #146 