### PR TITLE
Add test cases for DeleteCommand related classes

### DIFF
--- a/src/main/java/ezschedule/logic/commands/DeleteCommand.java
+++ b/src/main/java/ezschedule/logic/commands/DeleteCommand.java
@@ -40,7 +40,7 @@ public class DeleteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Event> lastShownList = model.getFilteredEventList();
-        StringBuilder feedback = new StringBuilder(MESSAGE_DELETE_EVENT_SUCCESS);
+        StringBuilder feedback = new StringBuilder();
         Collections.sort(targetIndexes); // sort index in order
         Collections.reverse(targetIndexes); // reverse index order to prevent exception when deleting
         model.clearRecent();
@@ -53,8 +53,9 @@ public class DeleteCommand extends Command {
             Event eventToDelete = lastShownList.get(targetIndex.getZeroBased());
             model.deleteEvent(eventToDelete);
             model.addRecentEvent(eventToDelete);
-            feedback.append(eventToDelete.toString());
+            feedback.insert(0, eventToDelete.toString());
         }
+        feedback.insert(0, MESSAGE_DELETE_EVENT_SUCCESS);
         return new CommandResult(feedback.toString());
     }
 

--- a/src/main/java/ezschedule/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/ezschedule/logic/parser/DeleteCommandParser.java
@@ -9,7 +9,7 @@ import ezschedule.logic.commands.DeleteCommand;
 import ezschedule.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new {@code DeleteCommand} object.
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 

--- a/src/test/java/ezschedule/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/ezschedule/logic/parser/DeleteCommandParserTest.java
@@ -4,6 +4,8 @@ import static ezschedule.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ezschedule.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static ezschedule.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static ezschedule.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static ezschedule.testutil.TypicalIndexes.INDEX_SECOND_EVENT;
+import static ezschedule.testutil.TypicalIndexes.INDEX_THIRD_EVENT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +24,7 @@ import ezschedule.logic.commands.DeleteCommand;
  */
 public class DeleteCommandParserTest {
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private final DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
@@ -32,7 +34,35 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_multipleValidArgs_returnsDeleteCommand() {
+        List<Index> multipleIndexes = new ArrayList<>();
+        multipleIndexes.add(INDEX_FIRST_EVENT);
+        multipleIndexes.add(INDEX_SECOND_EVENT);
+        multipleIndexes.add(INDEX_THIRD_EVENT);
+        assertParseSuccess(parser, "1 2 3", new DeleteCommand(multipleIndexes));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_ZeroIndex_throwsParseException() {
+        assertParseFailure(parser, "0",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeIndex_throwsParseException() {
+        assertParseFailure(parser, "-1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_mixOfValidAndInvalidIndexes_throwsParseException() {
+        assertParseFailure(parser, "-2 0 1 4",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/ezschedule/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/ezschedule/logic/parser/DeleteCommandParserTest.java
@@ -49,7 +49,7 @@ public class DeleteCommandParserTest {
     }
 
     @Test
-    public void parse_ZeroIndex_throwsParseException() {
+    public void parse_zeroIndex_throwsParseException() {
         assertParseFailure(parser, "0",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }


### PR DESCRIPTION
1. Change the ordering of delete result
- "delete 1 2 3" used to show delete result in the order of 3 2 1, it is now switched to order of 1 2 3

2. Add test cases to DeleteCommandTest and DeleteCommandParserTest