### PR TITLE
Fix bug that allows user to edit to existing event time

### DIFF
--- a/src/main/java/ezschedule/logic/commands/EditCommand.java
+++ b/src/main/java/ezschedule/logic/commands/EditCommand.java
@@ -44,6 +44,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the scheduler.";
+    public static final String MESSAGE_EVENT_EXIST_AT_TIME = "Another event already exists at the chosen time";
 
     private final Index index;
     private final EditEventDescriptor editEventDescriptor;
@@ -92,10 +93,12 @@ public class EditCommand extends Command {
         Event eventToEdit = lastShownList.get(index.getZeroBased());
         Event editedEvent = createEditedEvent(eventToEdit, editEventDescriptor);
 
-        if (!eventToEdit.equals(editedEvent) && model.hasEvent(editedEvent)) {
-            throw new CommandException(MESSAGE_DUPLICATE_EVENT);
-        } else if (editedEvent.getEndTime().isBefore(editedEvent.getStartTime())) {
+        if (editedEvent.getEndTime().isBefore(editedEvent.getStartTime())) {
             throw new CommandException(MESSAGE_EVENT_END_TIME_EARLIER_THAN_START_TIME);
+        } else if (!eventToEdit.equals(editedEvent) && model.hasEvent(editedEvent)) {
+            throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+        } else if (model.hasEventAtTime(eventToEdit, editedEvent)) {
+            throw new CommandException(MESSAGE_EVENT_EXIST_AT_TIME);
         } else {
             model.clearRecent();
             model.recentCommands().add(this);

--- a/src/main/java/ezschedule/model/Model.java
+++ b/src/main/java/ezschedule/model/Model.java
@@ -74,6 +74,13 @@ public interface Model {
      */
     boolean hasEventAtTime(Event event);
 
+
+    /**
+     * Returns true if another event exists (excluding {@code currentEvent})
+     * at the same time as {@code event} in the scheduler.
+     */
+    boolean hasEventAtTime(Event currentEvent, Event eventToCheck);
+
     /**
      * Adds the given event.
      * {@code event} must not already exist in the scheduler.

--- a/src/main/java/ezschedule/model/ModelManager.java
+++ b/src/main/java/ezschedule/model/ModelManager.java
@@ -118,7 +118,14 @@ public class ModelManager implements Model {
     @Override
     public boolean hasEventAtTime(Event event) {
         requireNonNull(event);
-        return scheduler.hasEventAtTime(event);
+        return scheduler.hasEventAtTime(null, event);
+    }
+
+    @Override
+    public boolean hasEventAtTime(Event current, Event toCheck) {
+        requireNonNull(current);
+        requireNonNull(toCheck);
+        return scheduler.hasEventAtTime(current, toCheck);
     }
 
     @Override

--- a/src/main/java/ezschedule/model/Scheduler.java
+++ b/src/main/java/ezschedule/model/Scheduler.java
@@ -82,9 +82,9 @@ public class Scheduler implements ReadOnlyScheduler {
     /**
      * Returns true if another event exists at the given date and time in the Scheduler.
      */
-    public boolean hasEventAtTime(Event event) {
-        requireNonNull(event);
-        return events.existsAtTime(event);
+    public boolean hasEventAtTime(Event currentEvent, Event eventToCheck) {
+        requireNonNull(eventToCheck);
+        return events.existsAtTime(currentEvent, eventToCheck);
     }
 
     /**

--- a/src/main/java/ezschedule/model/event/UniqueEventList.java
+++ b/src/main/java/ezschedule/model/event/UniqueEventList.java
@@ -36,11 +36,11 @@ public class UniqueEventList implements Iterable<Event> {
     }
 
     /**
-     * Returns true if the list contains an event at the given date and time.
+     * Returns true if the list contains an event (excluding {@code current}) at the given date and time.
      */
-    public boolean existsAtTime(Event toCheck) {
+    public boolean existsAtTime(Event current, Event toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isEventOverlap);
+        return internalList.stream().filter(e -> !e.equals(current)).anyMatch(toCheck::isEventOverlap);
     }
 
     /**

--- a/src/test/java/ezschedule/logic/commands/AddCommandTest.java
+++ b/src/test/java/ezschedule/logic/commands/AddCommandTest.java
@@ -148,6 +148,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasEventAtTime(Event current, Event toCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addEvent(Event event) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/ezschedule/logic/commands/EditCommandTest.java
+++ b/src/test/java/ezschedule/logic/commands/EditCommandTest.java
@@ -127,6 +127,15 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_eventExistsAtTime_failure() {
+        // edit event overlaps with first event of typical events
+        EditEventDescriptor descriptor = new EditEventDescriptorBuilder()
+                .withDate("2023-05-01").withStartTime("00:00").withEndTime("23:59").build();
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_EVENT, descriptor);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_EVENT_EXIST_AT_TIME);
+    }
+
+    @Test
     public void execute_invalidEventIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEventList().size() + 1);
         EditEventDescriptor descriptor = new EditEventDescriptorBuilder().withName(VALID_NAME_B).build();


### PR DESCRIPTION
- Added `hasEventAtTime` method to edit event (to check for overlap)
- `hasEventAtTime` uses `existsAtTime` method, where it counts itself (the current event) as another event (thus, adding `hasEventAtTim`e would prevent current to be edited to its own time)
- Modified `existsAtTime` method to exclude `currentEvent`
- Overloading of `hasEventAtTime` to prevent modifying of other methods that uses `hasEventAtTime`

Resolves #217 